### PR TITLE
fix: The annotations section can exist and be empty.

### DIFF
--- a/edx_repo_tools/release/tag_release.py
+++ b/edx_repo_tools/release/tag_release.py
@@ -91,11 +91,10 @@ def openedx_repos_with_catalog_info(hub, orgs=None, branches=None):
     orgs = orgs or OPENEDX_ORGS
     repos = {}
     for repo, data in tqdm(iter_openedx_yaml('catalog-info.yaml', hub, orgs=orgs, branches=branches), desc='Find repos'):
-        
+
         if 'metadata' in data:
-            if 'annotations' in data['metadata']:
-                annotations = data['metadata']['annotations']
-            
+            annotations = data['metadata'].get('annotations')
+            if annotations:
                 # Check if 'openedx.org/release' is present in annotations
                 if 'openedx.org/release' in annotations:
                     repo = repo.refresh()


### PR DESCRIPTION
For example:
```
metadata:
    annotations: null
```

This would be valid but would throw an error before this change because the code tries to use the `in` operator as if annotations is a collection.  But if it's a NoneType, it throws an error since a NoneType doesn't support the `in` operator.

We instead use the get method on the metadata collection which will return `None` if the key is not in the dict.  This allows us to bypass the `in` check for the `annotations` key and fix a potential error scenario because the code behaves the same way for the key not existing and for the value being none which is what we want in this case.